### PR TITLE
Docker-Compose Version deprecated

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 
 services:
 


### PR DESCRIPTION
Docker has deprecated the use of version in the root level of the docker compose yaml beginning with Docker Compose 1.27+.