### PR TITLE
Install PCNTL Extension  to avoid Undefined SIGINT Error

### DIFF
--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -29,6 +29,9 @@ RUN pecl install redis && docker-php-ext-enable redis
 # pcov
 RUN pecl install pcov && docker-php-ext-enable pcov
 
+# pcntl
+RUN docker-php-ext-install pcntl
+
 # Xdebug
 # RUN pecl install xdebug \
 # && docker-php-ext-enable xdebug \


### PR DESCRIPTION
When running Laravel Reverb, the following error appeared:
Undefined constant "Laravel\Reverb\Servers\Reverb\Console\Commands\SIGINT".
to avoid this error we need to install PCNTL extension.
:

